### PR TITLE
[Feat] 수강취소 API 구현 (#48)

### DIFF
--- a/backend/api/courses_api.py
+++ b/backend/api/courses_api.py
@@ -137,3 +137,15 @@ async def list_departments(
 ):
     return course_service.list_departments(year=year, semester=semester)
 
+
+@router.delete("/enroll/{courseId}", summary="수강취소")
+async def cancel_enrollment(courseId: str = Path(..., description="강의 ID")):
+    user_id = "12345678-1234-1234-1234-123456789012"  # demo-user UUID
+    cap = _rate_check_and_captcha(user_id)
+    if cap:
+        return cap
+    success = course_service.cancel_enrollment(user_id, courseId)
+    if not success:
+        raise HTTPException(status_code=404, detail="수강신청 내역을 찾을 수 없습니다.")
+    return {"success": True, "message": "수강취소가 완료되었습니다."}
+

--- a/backend/repositories/course_repository.py
+++ b/backend/repositories/course_repository.py
@@ -239,7 +239,7 @@ class CourseRepository:
         # Convert user_id to UUID if it's a string
         if isinstance(user_id, str):
             user_id = UUID(user_id)
-            
+
         with get_db_session() as session:
             courses = session.query(Course).join(Enrollment).filter(
                 Enrollment.user_id == user_id
@@ -254,6 +254,31 @@ class CourseRepository:
                 }
                 for course in courses
             ]
+
+    def cancel_enrollment(self, user_id: str, course_id: str) -> bool:
+        """Cancel user's enrollment for a course"""
+        # Convert user_id to UUID if it's a string
+        if isinstance(user_id, str):
+            user_id = UUID(user_id)
+
+        with get_db_session() as session:
+            # Find enrollment
+            enrollment = session.query(Enrollment).filter(
+                and_(Enrollment.user_id == user_id, Enrollment.course_id == course_id)
+            ).first()
+
+            if not enrollment:
+                return False
+
+            # Lock the course row and decrement enrolled_count
+            course = session.query(Course).filter(Course.id == course_id).with_for_update().first()
+            if course and course.enrolled_count > 0:
+                course.enrolled_count -= 1
+
+            # Delete enrollment
+            session.delete(enrollment)
+
+            return True
 
 
 course_repository = CourseRepository()

--- a/backend/services/course_service.py
+++ b/backend/services/course_service.py
@@ -168,7 +168,7 @@ class CourseService:
     def my_courses(self, user_id: str) -> List[Course]:
         """Get user's enrolled courses"""
         db_courses = course_repository.get_user_enrollments(user_id)
-        
+
         result = []
         for db_course in db_courses:
             demo_course = self.demo_courses.get(db_course["id"])
@@ -182,8 +182,12 @@ class CourseService:
                     enrolled=db_course["enrolled_count"]
                 )
                 result.append(course_data)
-        
+
         return result
+
+    def cancel_enrollment(self, user_id: str, course_id: str) -> bool:
+        """Cancel user's enrollment for a course"""
+        return course_repository.cancel_enrollment(user_id, course_id)
 
 
     def list_departments(self, *, year: Optional[int] = None, semester: Optional[int] = None) -> List[str]:

--- a/frontend/src/features/courses/hooks/useCourses.ts
+++ b/frontend/src/features/courses/hooks/useCourses.ts
@@ -38,7 +38,7 @@ export interface UseCoursesReturn {
   removeFromCart: (courseId: string) => Promise<void>;
   enroll: () => Promise<void>;
   enrollSingle: (courseId: string) => Promise<void>;
-  cancelEnrollment: (courseId: string) => void;
+  cancelEnrollment: (courseId: string) => Promise<void>;
   submitCaptcha: () => Promise<void>;
   refreshCaptcha: () => Promise<void>;
   setCaptchaInput: (value: string) => void;
@@ -73,16 +73,53 @@ export function useCourses(): UseCoursesReturn {
    * 수강취소를 처리하는 함수
    * @param {string} courseId - 취소할 강의 ID
    */
-  const cancelEnrollment = (courseId: string) => {
-    // 히스토리에서 해당 과목 제거
-    setEnrolledCourses(prev => prev.filter(course => course.courseId !== courseId));
+  const cancelEnrollment = async (courseId: string) => {
+    console.log('[cancelEnrollment] 시작:', courseId);
+    try {
+      const url = `/api/enroll/${courseId}`;
+      console.log('[cancelEnrollment] 요청 URL:', url);
 
-    // 강의 목록에서 enrolled 수를 1 감소 (프론트엔드에서만)
-    setCourses(prev => prev.map(course =>
-      course.courseId === courseId
-        ? { ...course, enrolled: Math.max(0, course.enrolled - 1) }
-        : course
-    ));
+      const res = await fetch(url, { method: 'DELETE' });
+      console.log('[cancelEnrollment] 응답 상태:', res.status);
+
+      let data: any = {};
+      try {
+        data = await res.json();
+        console.log('[cancelEnrollment] 응답 데이터:', data);
+      } catch (e) {
+        console.error('[cancelEnrollment] JSON 파싱 오류:', e);
+      }
+
+      if (openCaptchaIfNeeded(data)) {
+        console.log('[cancelEnrollment] 캡챠 필요');
+        return;
+      }
+
+      if (data?.success) {
+        console.log('[cancelEnrollment] 성공');
+        // 히스토리에서 해당 과목 제거
+        setEnrolledCourses(prev => prev.filter(course => course.courseId !== courseId));
+
+        // 강의 목록에서 enrolled 수를 1 감소
+        setCourses(prev => prev.map(course =>
+          course.courseId === courseId
+            ? { ...course, enrolled: Math.max(0, course.enrolled - 1) }
+            : course
+        ));
+
+        setMessage('수강취소가 완료되었습니다.');
+
+        // 데이터 다시 가져오기
+        await fetchCourses();
+        await fetchMyCourses();
+      } else {
+        console.error('[cancelEnrollment] 실패:', data?.message);
+        setMessage(data?.message || '수강취소에 실패했습니다.');
+      }
+    } catch (error) {
+      console.error('[cancelEnrollment] 예외 오류:', error);
+      setMessage('수강취소 중 오류가 발생했습니다.');
+    }
   };
 
   /**


### PR DESCRIPTION
### 개요

수강목록에서 “수강취소” 버튼을 클릭하면
데이터베이스의 수강신청 내역이 삭제되고, 해당 강의의 정원이 감소하도록 하는 기능을 구현했습니다.
프론트엔드와 백엔드를 연동하여 완전한 수강취소 플로우를 구성했습니다.

---

### 주요 변경사항

**백엔드**

* `DELETE /api/enroll/{courseId}` 엔드포인트 추가 (`courses_api.py`)
* `course_repository.py`: `cancel_enrollment(user_id, course_id)` 구현

  * `Enrollment` 레코드 삭제
  * `Course.enrolled_count` 1 감소 (`with_for_update()` 사용)
  * 트랜잭션 처리로 원자성 보장
* `course_service.py`: Repository 호출용 서비스 메서드 추가
* Rate limiting 및 CAPTCHA 검증 포함

**프론트엔드**

* `useCourses.ts`:

  * `cancelEnrollment()` 비동기 함수 추가
  * `DELETE /api/enroll/${courseId}` 호출
  * UI 상태(`enrolledCourses`, `courses`) 갱신
  * 성공 메시지 및 오류 메시지 표시

---

### 테스트 방법

1. 백엔드 서버 재시작

   ```bash
   cd backend
   uvicorn main:app --reload --host 0.0.0.0 --port 8000
   ```
2. 브라우저에서 수강신청 페이지 접속
3. “수강취소” 버튼 클릭
4. 콘솔 로그 및 UI 변경 확인
5. 또는 curl 테스트

   ```bash
   curl -X DELETE "http://localhost:8000/api/enroll/CS5525"
   ```

---

### 참고 파일

* `backend/api/courses_api.py`
* `backend/repositories/course_repository.py`
* `backend/services/course_service.py`
* `frontend/src/features/courses/hooks/useCourses.ts`